### PR TITLE
feat: add reusable automatic releases

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -1,0 +1,77 @@
+name: Auto Release
+
+on:
+  workflow_call:
+    inputs:
+      release_type:
+        description: 'Optional release type (major, minor, patch)'
+        required: false
+        type: string
+        default: ''
+
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TYPE: ${{ inputs.release_type }}
+        run: |
+          set -euo pipefail
+
+          release_type="$RELEASE_TYPE"
+          if [[ -z "$release_type" ]]; then
+            message="$(git log -1 --format=%B "$GITHUB_SHA")"
+            header="${message%%$'\n'*}"
+            breaking_header='^[A-Za-z][A-Za-z0-9_-]*(\([^)]+\))?!:'
+            fix_header='^fix(\([^)]+\))?:'
+
+            if [[ "$header" =~ $breaking_header ]] \
+              || [[ "$message" == "BREAKING CHANGE:"* ]] \
+              || [[ "$message" == *$'\nBREAKING CHANGE:'* ]]; then
+              release_type=major
+            elif [[ "$header" =~ $fix_header ]]; then
+              release_type=patch
+            else
+              release_type=minor
+            fi
+          fi
+
+          latest_tag="$(git tag --list | awk '/^v[0-9]+\.[0-9]+\.[0-9]+$/' | sort -V | tail -n 1)"
+          if [[ -z "$latest_tag" ]]; then
+            echo "No valid vX.Y.Z tag found. Create an initial version tag first."
+            exit 1
+          fi
+
+          IFS=. read -r major minor patch <<< "${latest_tag#v}"
+          major=$((10#$major))
+          minor=$((10#$minor))
+          patch=$((10#$patch))
+
+          case "$release_type" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+            *) echo "Invalid release type: $release_type"; exit 1 ;;
+          esac
+
+          new_tag="v$major.$minor.$patch"
+          major_branch="v$major"
+
+          git tag "$new_tag" "$GITHUB_SHA"
+          gh auth setup-git
+          git push origin "refs/tags/$new_tag"
+          git push --force-with-lease origin "$GITHUB_SHA:refs/heads/$major_branch"
+          gh release create "$new_tag" --verify-tag --target "$GITHUB_SHA" --generate-notes --title "$new_tag"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       release_type:
@@ -13,97 +16,10 @@ on:
           - minor
           - patch
 
-permissions:
-  contents: write
-
 jobs:
   release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-        with:
-          fetch-depth: 0
-
-      - name: Create SemVer Release
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const sha = context.sha;
-            const releaseType = '${{ inputs.release_type }}';
-
-            let latestTag = null;
-            try {
-              const tags = await github.rest.repos.listTags({ 
-                owner, 
-                repo, 
-                per_page: 1 
-              });
-              if (tags.data.length > 0) {
-                latestTag = tags.data[0].name;
-              }
-            } catch (error) {
-              core.setFailed(`Error fetching tags: ${error.message}`);
-              return;
-            }
-
-            if (!latestTag) {
-              core.setFailed('No existing tags found. Please create an initial tag (e.g., v0.1.0) before using this workflow.');
-              return;
-            }
-
-            core.info(`Found latest tag: ${latestTag}`);
-
-            let [major, minor, patch] = latestTag.replace(/^v/, '').split('.').map(Number);
-
-            if (isNaN(major) || isNaN(minor) || isNaN(patch)) {
-              core.setFailed(`Invalid version format in tag: ${latestTag}. Expected format: vX.Y.Z`);
-              return;
-            }
-
-            switch (releaseType) {
-              case 'major':
-                major += 1;
-                minor = 0;
-                patch = 0;
-                core.info('Incrementing major version');
-                break;
-              case 'minor':
-                minor += 1;
-                patch = 0;
-                core.info('Incrementing minor version');
-                break;
-              case 'patch':
-                patch += 1;
-                core.info('Incrementing patch version');
-                break;
-              default:
-                core.setFailed(`Invalid release type: ${releaseType}`);
-                return;
-            }
-
-            const newTag = `v${major}.${minor}.${patch}`;
-            core.info(`Creating new tag: ${newTag}`);
-
-            await github.rest.git.createRef({
-              owner,
-              repo,
-              ref: `refs/tags/${newTag}`,
-              sha: sha
-            });
-
-            await github.rest.repos.createRelease({
-              owner,
-              repo,
-              tag_name: newTag,
-              name: newTag,
-              generate_release_notes: true,
-              draft: false,
-              prerelease: false
-            });
-
-            core.info(`Successfully created release ${newTag}`);
-            core.setOutput('tag', newTag);
+    permissions:
+      contents: write
+    uses: ./.github/workflows/auto_release.yml
+    with:
+      release_type: ${{ github.event_name == 'workflow_dispatch' && inputs.release_type || '' }}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # reusable-workflows
 
-Reusable workflows for Dependabot/GitHub Advanced Security
+Reusable GitHub Actions workflows for security, dependency management, and releases.
 
 ## Workflows
 
-This repository contains reusable GitHub Actions workflows for security and dependency management:
+This repository contains the following reusable workflows:
 
 - **PR Dependency Review** - Reviews dependencies in pull requests using GitHub's dependency review action
 - **SBOM Upload** - Generates Software Bill of Materials (SBOM) using Trivy
+- **Auto Release** - Creates SemVer releases and updates the floating major branch
 
 ## Usage
 
@@ -45,6 +46,24 @@ jobs:
   sbom:
     uses: appsecdemos/reusable-workflows/.github/workflows/sbom_upload.yml@v1
     secrets: inherit
+```
+
+### Auto Release
+
+Use this workflow with an existing `vX.Y.Z` tag to release automatically from Conventional Commits (`!` or `BREAKING CHANGE:` for major, `fix:` for patch, and everything else for minor); callers can pass `release_type` to select major, minor, or patch explicitly.
+
+```yaml
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    uses: appsecdemos/reusable-workflows/.github/workflows/auto_release.yml@v1
 ```
 
 ### Combined Example


### PR DESCRIPTION
## Summary

- Add a reusable automatic release workflow
- Release pushes to `main` using Conventional Commit bumps
- Retain manual major, minor, and patch releases
- Harden `GITHUB_TOKEN` handling
- Document reusable workflow usage